### PR TITLE
fix: Adding missed network configurations

### DIFF
--- a/sg_network_config.md
+++ b/sg_network_config.md
@@ -4,7 +4,7 @@
 
 copyright:
   years: 2017
-lastupdated: "2018-11-10"
+lastupdated: "2024-04-03"
 
 keywords: configuration, network, virtual server, instance, security
 
@@ -20,6 +20,10 @@ subcollection: security-groups
 
 A security group augments any existing network configuration. Therefore, a security group cannot span across networks that cannot communicate with one another.
 {: shortdesc}
+
+Security groups are interface constructs, they're not IP specific. When a virtual server has public interface with security group applied, it is applicable to its assigned(with the interface) portal subnet also.
+
+In order to prevent DHCP spoofing, a DROP rule is added as a mandate whenever the secuirty group is applied. so, trying to set DHCP server using secondary portable subnet will not work with security applied.
 
 If virtual server instances cannot communicate with one another, adding them to a security group does not change that behavior. Gateways must allow the traffic that is defined by the selected security groups.
 

--- a/sg_network_config.md
+++ b/sg_network_config.md
@@ -21,7 +21,7 @@ subcollection: security-groups
 A security group augments any existing network configuration. Therefore, a security group cannot span across networks that cannot communicate with one another.
 {: shortdesc}
 
-Security groups are interface constructs, they're not IP specific. When a virtual server has public interface with security group applied, it is applicable to its assigned(with the interface) portal subnet also.
+Security groups are interface constructs, they're not IP specific. When a virtual server has public interface with security group applied, the security group also applies to the interfaces assigned portable subnet.
 
 In order to prevent DHCP spoofing, a DROP rule is added as a mandate whenever the secuirty group is applied. so, trying to set DHCP server using secondary portable subnet will not work with security applied.
 

--- a/sg_network_config.md
+++ b/sg_network_config.md
@@ -23,7 +23,7 @@ A security group augments any existing network configuration. Therefore, a secur
 
 Security groups are interface constructs, they're not IP specific. When a virtual server has public interface with security group applied, the security group also applies to the interfaces assigned portable subnet.
 
-In order to prevent DHCP spoofing, a DROP rule is added as a mandate whenever the secuirty group is applied. so, trying to set DHCP server using secondary portable subnet will not work with security applied.
+In order to prevent DHCP spoofing, a DROP rule is added as a mandate whenever the secuirty group is applied. As such, trying to set DHCP server using secondary portable subnet will not work with a security group applied.
 
 If virtual server instances cannot communicate with one another, adding them to a security group does not change that behavior. Gateways must allow the traffic that is defined by the selected security groups.
 


### PR DESCRIPTION
1. Explains security groups are interface constructs
2. Mandate DHCP spoofing prevention rule